### PR TITLE
Allocate receipt amounts to schedules fifo

### DIFF
--- a/README_FIFO_Allocation.md
+++ b/README_FIFO_Allocation.md
@@ -1,0 +1,111 @@
+# FIFO Allocation System for Journal Voucher Schedules
+
+This solution implements a FIFO (First In, First Out) allocation system that updates the `received_amount` field in the `accounting_journal_voucher_line_schedules` table based on allocations from the `accounting_receipt_allocations` table.
+
+## Problem Description
+
+You have journal voucher lines with multiple payment schedules, and you need to allocate received amounts to these schedules in chronological order (FIFO). For example:
+- JV Line ID 396 has 3 schedules: 160, 160, and 180
+- Total allocated: 500 USD
+- Result: First schedule gets 160, second gets 160, third gets 180
+
+## Files Created
+
+### 1. `fifo_allocation_update.sql`
+Main script that performs the FIFO allocation update for all journal voucher lines.
+
+**Features:**
+- Calculates total allocations per JV line from `accounting_receipt_allocations`
+- Orders schedules by `schedule_date` and `id` (FIFO)
+- Uses window functions to calculate cumulative amounts
+- Updates `received_amount` field with proper FIFO logic
+- Provides before/after verification queries
+
+### 2. `test_example_jv_396.sql`
+Test script specifically for your example (JV Line ID 396).
+
+**Features:**
+- Shows current state of JV Line 396
+- Displays allocations for the line
+- Demonstrates step-by-step FIFO calculation
+- Provides example calculation with your specific numbers
+
+### 3. `fifo_allocation_procedure.sql`
+Reusable stored procedure for ongoing FIFO allocation updates.
+
+**Features:**
+- Can update all JV lines or a specific JV line
+- Includes error handling and transaction management
+- Returns detailed summary and verification results
+- Customizable `modified_by` parameter
+
+## FIFO Logic Explanation
+
+The allocation follows this logic for each schedule (ordered by date):
+
+1. **No Allocation**: If total allocated ≤ cumulative amount of previous schedules
+   - `received_amount = 0`
+
+2. **Full Allocation**: If total allocated ≥ cumulative amount including this schedule
+   - `received_amount = schedule_amount`
+
+3. **Partial Allocation**: If total allocated falls within this schedule's range
+   - `received_amount = total_allocated - cumulative_amount_of_previous_schedules`
+
+## Usage Instructions
+
+### Option 1: One-time Update (All JV Lines)
+```sql
+-- Execute the main update script
+source fifo_allocation_update.sql;
+```
+
+### Option 2: Test Specific JV Line
+```sql
+-- Test with JV Line 396 example
+source test_example_jv_396.sql;
+```
+
+### Option 3: Use Stored Procedure
+```sql
+-- Create the procedure
+source fifo_allocation_procedure.sql;
+
+-- Update all JV lines
+CALL UpdateFIFOAllocation();
+
+-- Update specific JV line (e.g., 396)
+CALL UpdateFIFOAllocation(396, 'USER_UPDATE');
+
+-- Update all with custom modified_by
+CALL UpdateFIFOAllocation(NULL, 'BATCH_PROCESS');
+```
+
+## Example Calculation
+
+For JV Line ID 396 with schedules [160, 160, 180] and 500 USD allocated:
+
+| Schedule | Date Order | Schedule Amount | Previous Cumulative | Available After Previous | Received Amount |
+|----------|------------|-----------------|-------------------|-------------------------|----------------|
+| 1        | 1          | 160            | 0                 | 500 - 0 = 500         | min(160, 500) = 160 |
+| 2        | 2          | 160            | 160               | 500 - 160 = 340       | min(160, 340) = 160 |
+| 3        | 3          | 180            | 320               | 500 - 320 = 180       | min(180, 180) = 180 |
+
+**Total Allocated: 160 + 160 + 180 = 500 ✓**
+
+## Key Features
+
+- **Database-level FIFO**: Uses SQL window functions for efficient processing
+- **Transaction Safety**: Includes proper transaction handling
+- **Verification**: Provides before/after comparison
+- **Flexibility**: Can target specific JV lines or process all
+- **Audit Trail**: Updates `modified_at` and `modified_by` fields
+- **Currency Handling**: Properly handles USD amounts from allocations table
+
+## Important Notes
+
+1. The script uses `schedule_date` and `id` for ordering (FIFO)
+2. Currency conversion: Uses `amount` for USD currency, `usd` field for others
+3. All calculations are done at the database level for consistency
+4. The procedure includes error handling and rollback on failure
+5. Results are limited to 100 records for performance in the procedure output

--- a/fifo_allocation_procedure.sql
+++ b/fifo_allocation_procedure.sql
@@ -1,0 +1,159 @@
+-- Stored Procedure for FIFO Allocation
+-- This creates a reusable procedure to update received amounts using FIFO logic
+
+DELIMITER //
+
+DROP PROCEDURE IF EXISTS UpdateFIFOAllocation//
+
+CREATE PROCEDURE UpdateFIFOAllocation(
+    IN p_jv_line_id INT DEFAULT NULL,  -- Optional: specific JV line ID, NULL for all
+    IN p_modified_by VARCHAR(50) DEFAULT 'FIFO_ALLOCATION_PROC'
+)
+BEGIN
+    DECLARE v_total_updated INT DEFAULT 0;
+    DECLARE v_total_processed INT DEFAULT 0;
+    DECLARE v_jv_lines_affected INT DEFAULT 0;
+    
+    -- Error handling
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        GET DIAGNOSTICS CONDITION 1
+            @p1 = RETURNED_SQLSTATE, @p2 = MESSAGE_TEXT;
+        SELECT 'ERROR' as status, @p1 as sql_state, @p2 as message;
+    END;
+    
+    START TRANSACTION;
+    
+    -- Create temporary table for calculations
+    DROP TEMPORARY TABLE IF EXISTS temp_fifo_allocation;
+    
+    CREATE TEMPORARY TABLE temp_fifo_allocation AS
+    WITH 
+    -- Get total allocated amount per journal voucher line from allocations table
+    allocated_amounts AS (
+        SELECT 
+            jv_line_id,
+            SUM(CASE 
+                WHEN currency = 'USD' THEN amount 
+                ELSE usd 
+            END) as total_allocated_usd
+        FROM accounting_receipt_allocations 
+        WHERE jv_line_id IS NOT NULL
+            AND (p_jv_line_id IS NULL OR jv_line_id = p_jv_line_id)
+        GROUP BY jv_line_id
+    ),
+    
+    -- Get schedules ordered by date (FIFO) with cumulative amounts
+    schedule_cumulative AS (
+        SELECT 
+            id,
+            journal_voucher_line_id,
+            schedule_date,
+            schedule_amount,
+            received_amount,
+            -- Calculate cumulative schedule amounts up to current row (FIFO order)
+            SUM(schedule_amount) OVER (
+                PARTITION BY journal_voucher_line_id 
+                ORDER BY schedule_date, id 
+                ROWS UNBOUNDED PRECEDING
+            ) as cumulative_schedule_amount,
+            -- Calculate cumulative schedule amounts up to previous row
+            COALESCE(
+                SUM(schedule_amount) OVER (
+                    PARTITION BY journal_voucher_line_id 
+                    ORDER BY schedule_date, id 
+                    ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+                ), 0
+            ) as previous_cumulative_amount,
+            ROW_NUMBER() OVER (
+                PARTITION BY journal_voucher_line_id 
+                ORDER BY schedule_date, id
+            ) as schedule_order
+        FROM accounting_journal_voucher_line_schedules
+        WHERE (p_jv_line_id IS NULL OR journal_voucher_line_id = p_jv_line_id)
+    )
+    
+    SELECT 
+        sc.id,
+        sc.journal_voucher_line_id,
+        sc.schedule_date,
+        sc.schedule_amount,
+        sc.received_amount as current_received_amount,
+        COALESCE(aa.total_allocated_usd, 0) as total_allocated,
+        sc.cumulative_schedule_amount,
+        sc.previous_cumulative_amount,
+        sc.schedule_order,
+        -- Calculate new received amount using FIFO logic
+        CASE 
+            WHEN COALESCE(aa.total_allocated_usd, 0) = 0 THEN 0
+            WHEN aa.total_allocated_usd <= sc.previous_cumulative_amount THEN 0
+            WHEN aa.total_allocated_usd >= sc.cumulative_schedule_amount THEN sc.schedule_amount
+            ELSE GREATEST(0, aa.total_allocated_usd - sc.previous_cumulative_amount)
+        END as new_received_amount
+    FROM schedule_cumulative sc
+    LEFT JOIN allocated_amounts aa ON sc.journal_voucher_line_id = aa.jv_line_id
+    ORDER BY sc.journal_voucher_line_id, sc.schedule_date, sc.id;
+    
+    -- Get statistics before update
+    SELECT 
+        COUNT(*) INTO v_total_processed,
+        COUNT(DISTINCT journal_voucher_line_id) INTO v_jv_lines_affected
+    FROM temp_fifo_allocation;
+    
+    -- Update the actual table with the calculated received amounts
+    UPDATE accounting_journal_voucher_line_schedules ajvls
+    INNER JOIN temp_fifo_allocation tfa ON ajvls.id = tfa.id
+    SET ajvls.received_amount = tfa.new_received_amount,
+        ajvls.modified_at = CURRENT_TIMESTAMP,
+        ajvls.modified_by = p_modified_by
+    WHERE ajvls.received_amount != tfa.new_received_amount;
+    
+    -- Get count of updated records
+    SET v_total_updated = ROW_COUNT();
+    
+    -- Return summary information
+    SELECT 
+        'SUCCESS' as status,
+        v_total_processed as total_schedules_processed,
+        v_total_updated as schedules_updated,
+        v_jv_lines_affected as jv_lines_affected,
+        CASE 
+            WHEN p_jv_line_id IS NOT NULL THEN CONCAT('JV Line ID: ', p_jv_line_id)
+            ELSE 'All JV Lines'
+        END as scope;
+    
+    -- Show detailed results for verification (limit to first 100 records)
+    SELECT 
+        'UPDATED_RECORDS' as record_type,
+        tfa.journal_voucher_line_id,
+        tfa.schedule_date,
+        tfa.schedule_amount,
+        tfa.current_received_amount as old_received_amount,
+        tfa.new_received_amount,
+        tfa.total_allocated,
+        tfa.schedule_order
+    FROM temp_fifo_allocation tfa
+    WHERE tfa.current_received_amount != tfa.new_received_amount
+    ORDER BY tfa.journal_voucher_line_id, tfa.schedule_order
+    LIMIT 100;
+    
+    -- Clean up
+    DROP TEMPORARY TABLE temp_fifo_allocation;
+    
+    COMMIT;
+    
+END//
+
+DELIMITER ;
+
+-- Usage examples:
+
+-- Example 1: Update all JV lines
+-- CALL UpdateFIFOAllocation();
+
+-- Example 2: Update specific JV line (your example)
+-- CALL UpdateFIFOAllocation(396, 'USER_FIFO_UPDATE');
+
+-- Example 3: Update with custom modified_by
+-- CALL UpdateFIFOAllocation(NULL, 'BATCH_FIFO_PROCESS');

--- a/fifo_allocation_procedure.sql
+++ b/fifo_allocation_procedure.sql
@@ -6,13 +6,18 @@ DELIMITER //
 DROP PROCEDURE IF EXISTS UpdateFIFOAllocation//
 
 CREATE PROCEDURE UpdateFIFOAllocation(
-    IN p_jv_line_id INT DEFAULT NULL,  -- Optional: specific JV line ID, NULL for all
-    IN p_modified_by VARCHAR(50) DEFAULT 'FIFO_ALLOCATION_PROC'
+    IN p_jv_line_id INT,  -- Optional: specific JV line ID, NULL for all
+    IN p_modified_by VARCHAR(50)  -- Modified by user identifier
 )
 BEGIN
     DECLARE v_total_updated INT DEFAULT 0;
     DECLARE v_total_processed INT DEFAULT 0;
     DECLARE v_jv_lines_affected INT DEFAULT 0;
+    
+    -- Handle default values
+    IF p_modified_by IS NULL OR p_modified_by = '' THEN
+        SET p_modified_by = 'FIFO_ALLOCATION_PROC';
+    END IF;
     
     -- Error handling
     DECLARE EXIT HANDLER FOR SQLEXCEPTION
@@ -147,13 +152,31 @@ END//
 
 DELIMITER ;
 
+-- Create a convenience procedure for updating all JV lines with default settings
+DELIMITER //
+
+DROP PROCEDURE IF EXISTS UpdateAllFIFOAllocation//
+
+CREATE PROCEDURE UpdateAllFIFOAllocation()
+BEGIN
+    CALL UpdateFIFOAllocation(NULL, 'FIFO_ALLOCATION_PROC');
+END//
+
+DELIMITER ;
+
 -- Usage examples:
 
--- Example 1: Update all JV lines
--- CALL UpdateFIFOAllocation();
+-- Example 1: Simplest - Update all JV lines (uses convenience procedure)
+-- CALL UpdateAllFIFOAllocation();
 
--- Example 2: Update specific JV line (your example)
+-- Example 2: Update all JV lines with default modified_by
+-- CALL UpdateFIFOAllocation(NULL, NULL);
+
+-- Example 3: Update specific JV line (your example)
 -- CALL UpdateFIFOAllocation(396, 'USER_FIFO_UPDATE');
 
--- Example 3: Update with custom modified_by
+-- Example 4: Update all JV lines with custom modified_by
 -- CALL UpdateFIFOAllocation(NULL, 'BATCH_FIFO_PROCESS');
+
+-- Example 5: Update specific JV line with default modified_by
+-- CALL UpdateFIFOAllocation(396, NULL);

--- a/fifo_allocation_update.sql
+++ b/fifo_allocation_update.sql
@@ -1,0 +1,119 @@
+-- FIFO Allocation Update Script
+-- This script updates the received_amount in accounting_journal_voucher_line_schedules
+-- based on allocations in accounting_receipt_allocations using FIFO logic
+
+-- Step 1: Create a temporary table to calculate cumulative allocations and schedule amounts
+DROP TEMPORARY TABLE IF EXISTS temp_fifo_calculation;
+
+CREATE TEMPORARY TABLE temp_fifo_calculation AS
+WITH 
+-- Get total allocated amount per journal voucher line from allocations table
+allocated_amounts AS (
+    SELECT 
+        jv_line_id,
+        SUM(CASE 
+            WHEN currency = 'USD' THEN amount 
+            ELSE usd 
+        END) as total_allocated_usd
+    FROM accounting_receipt_allocations 
+    WHERE jv_line_id IS NOT NULL
+    GROUP BY jv_line_id
+),
+
+-- Get schedules ordered by date (FIFO) with cumulative amounts
+schedule_cumulative AS (
+    SELECT 
+        id,
+        journal_voucher_line_id,
+        schedule_date,
+        schedule_amount,
+        received_amount,
+        -- Calculate cumulative schedule amounts up to current row (FIFO order)
+        SUM(schedule_amount) OVER (
+            PARTITION BY journal_voucher_line_id 
+            ORDER BY schedule_date, id 
+            ROWS UNBOUNDED PRECEDING
+        ) as cumulative_schedule_amount,
+        -- Calculate cumulative schedule amounts up to previous row
+        COALESCE(
+            SUM(schedule_amount) OVER (
+                PARTITION BY journal_voucher_line_id 
+                ORDER BY schedule_date, id 
+                ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+            ), 0
+        ) as previous_cumulative_amount,
+        ROW_NUMBER() OVER (
+            PARTITION BY journal_voucher_line_id 
+            ORDER BY schedule_date, id
+        ) as schedule_order
+    FROM accounting_journal_voucher_line_schedules
+)
+
+SELECT 
+    sc.id,
+    sc.journal_voucher_line_id,
+    sc.schedule_date,
+    sc.schedule_amount,
+    sc.received_amount as current_received_amount,
+    COALESCE(aa.total_allocated_usd, 0) as total_allocated,
+    sc.cumulative_schedule_amount,
+    sc.previous_cumulative_amount,
+    sc.schedule_order,
+    -- Calculate new received amount using FIFO logic
+    CASE 
+        WHEN COALESCE(aa.total_allocated_usd, 0) = 0 THEN 0
+        WHEN aa.total_allocated_usd <= sc.previous_cumulative_amount THEN 0
+        WHEN aa.total_allocated_usd >= sc.cumulative_schedule_amount THEN sc.schedule_amount
+        ELSE GREATEST(0, aa.total_allocated_usd - sc.previous_cumulative_amount)
+    END as new_received_amount
+FROM schedule_cumulative sc
+LEFT JOIN allocated_amounts aa ON sc.journal_voucher_line_id = aa.jv_line_id
+ORDER BY sc.journal_voucher_line_id, sc.schedule_date, sc.id;
+
+-- Step 2: Show the calculation results before updating (for verification)
+SELECT 
+    'BEFORE UPDATE - Calculation Preview' as status,
+    journal_voucher_line_id,
+    schedule_date,
+    schedule_amount,
+    current_received_amount,
+    new_received_amount,
+    total_allocated,
+    schedule_order
+FROM temp_fifo_calculation
+ORDER BY journal_voucher_line_id, schedule_order;
+
+-- Step 3: Update the actual table with the calculated received amounts
+UPDATE accounting_journal_voucher_line_schedules ajvls
+INNER JOIN temp_fifo_calculation tfc ON ajvls.id = tfc.id
+SET ajvls.received_amount = tfc.new_received_amount,
+    ajvls.modified_at = CURRENT_TIMESTAMP,
+    ajvls.modified_by = 'FIFO_ALLOCATION_SCRIPT'
+WHERE ajvls.received_amount != tfc.new_received_amount;
+
+-- Step 4: Show summary of changes
+SELECT 
+    'UPDATE SUMMARY' as status,
+    COUNT(*) as total_schedules_processed,
+    SUM(CASE WHEN current_received_amount != new_received_amount THEN 1 ELSE 0 END) as schedules_updated,
+    COUNT(DISTINCT journal_voucher_line_id) as jv_lines_affected
+FROM temp_fifo_calculation;
+
+-- Step 5: Show detailed results after update
+SELECT 
+    'AFTER UPDATE - Results' as status,
+    ajvls.journal_voucher_line_id,
+    ajvls.schedule_date,
+    ajvls.schedule_amount,
+    ajvls.received_amount,
+    tfc.total_allocated,
+    ROW_NUMBER() OVER (
+        PARTITION BY ajvls.journal_voucher_line_id 
+        ORDER BY ajvls.schedule_date, ajvls.id
+    ) as schedule_order
+FROM accounting_journal_voucher_line_schedules ajvls
+INNER JOIN temp_fifo_calculation tfc ON ajvls.id = tfc.id
+ORDER BY ajvls.journal_voucher_line_id, ajvls.schedule_date, ajvls.id;
+
+-- Clean up
+DROP TEMPORARY TABLE temp_fifo_calculation;

--- a/test_example_jv_396.sql
+++ b/test_example_jv_396.sql
@@ -1,0 +1,110 @@
+-- Test Example for JV LINE ID 396
+-- This demonstrates the FIFO allocation logic with your specific example
+-- Allocated: 500 USD, Schedules: 160, 160, 180
+
+-- First, let's see the current state of JV LINE ID 396
+SELECT 
+    'CURRENT STATE - JV LINE 396' as status,
+    id,
+    journal_voucher_line_id,
+    schedule_date,
+    schedule_amount,
+    received_amount
+FROM accounting_journal_voucher_line_schedules 
+WHERE journal_voucher_line_id = 396
+ORDER BY schedule_date, id;
+
+-- Check allocations for JV LINE 396
+SELECT 
+    'ALLOCATIONS FOR JV LINE 396' as status,
+    allocation_id,
+    receipt_id,
+    jv_line_id,
+    amount,
+    currency,
+    usd,
+    CASE 
+        WHEN currency = 'USD' THEN amount 
+        ELSE usd 
+    END as effective_usd_amount
+FROM accounting_receipt_allocations 
+WHERE jv_line_id = 396;
+
+-- Demonstrate FIFO calculation step by step
+WITH allocated_total AS (
+    SELECT 
+        jv_line_id,
+        SUM(CASE 
+            WHEN currency = 'USD' THEN amount 
+            ELSE usd 
+        END) as total_allocated_usd
+    FROM accounting_receipt_allocations 
+    WHERE jv_line_id = 396
+    GROUP BY jv_line_id
+),
+schedule_analysis AS (
+    SELECT 
+        id,
+        journal_voucher_line_id,
+        schedule_date,
+        schedule_amount,
+        received_amount,
+        ROW_NUMBER() OVER (ORDER BY schedule_date, id) as sequence_order,
+        SUM(schedule_amount) OVER (ORDER BY schedule_date, id ROWS UNBOUNDED PRECEDING) as cumulative_amount,
+        COALESCE(SUM(schedule_amount) OVER (ORDER BY schedule_date, id ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING), 0) as previous_cumulative
+    FROM accounting_journal_voucher_line_schedules
+    WHERE journal_voucher_line_id = 396
+)
+SELECT 
+    'FIFO CALCULATION BREAKDOWN' as status,
+    sa.sequence_order,
+    sa.schedule_date,
+    sa.schedule_amount,
+    sa.received_amount as current_received,
+    at.total_allocated_usd as total_available,
+    sa.previous_cumulative as amount_used_by_previous_schedules,
+    sa.cumulative_amount as cumulative_including_this_schedule,
+    -- FIFO Logic explanation
+    CASE 
+        WHEN at.total_allocated_usd <= sa.previous_cumulative THEN 
+            CONCAT('No allocation (', at.total_allocated_usd, ' <= ', sa.previous_cumulative, ')')
+        WHEN at.total_allocated_usd >= sa.cumulative_amount THEN 
+            CONCAT('Full allocation (', at.total_allocated_usd, ' >= ', sa.cumulative_amount, ')')
+        ELSE 
+            CONCAT('Partial allocation (', at.total_allocated_usd, ' - ', sa.previous_cumulative, ' = ', 
+                   (at.total_allocated_usd - sa.previous_cumulative), ')')
+    END as allocation_logic,
+    -- Calculated received amount
+    CASE 
+        WHEN at.total_allocated_usd <= sa.previous_cumulative THEN 0
+        WHEN at.total_allocated_usd >= sa.cumulative_amount THEN sa.schedule_amount
+        ELSE GREATEST(0, at.total_allocated_usd - sa.previous_cumulative)
+    END as calculated_received_amount
+FROM schedule_analysis sa
+CROSS JOIN allocated_total at
+ORDER BY sa.sequence_order;
+
+-- Example with your specific numbers (assuming schedules are 160, 160, 180 and allocation is 500)
+SELECT 
+    'EXAMPLE CALCULATION WITH YOUR NUMBERS' as status,
+    'Schedule 1: 160' as schedule_info,
+    'Available: 500, Used by previous: 0' as calculation,
+    'Result: min(160, 500-0) = 160' as result
+UNION ALL
+SELECT 
+    '',
+    'Schedule 2: 160',
+    'Available: 500, Used by previous: 160',
+    'Result: min(160, 500-160) = 160'
+UNION ALL
+SELECT 
+    '',
+    'Schedule 3: 180',
+    'Available: 500, Used by previous: 320',
+    'Result: min(180, 500-320) = 180'
+UNION ALL
+SELECT 
+    '',
+    'Total Allocated: 160+160+180 = 500',
+    'Matches available allocation',
+    'Perfect FIFO allocation';


### PR DESCRIPTION
Implement FIFO allocation to update `received_amount` in journal voucher line schedules based on receipt allocations, ensuring chronological distribution.

The system previously lacked a mechanism to distribute a single allocated amount across multiple payment schedules for a Journal Voucher line in a First-In, First-Out manner. This change introduces SQL logic using window functions to correctly apply allocated funds to schedules based on their `schedule_date`, filling earlier schedules before later ones. For example, if 500 USD is allocated to schedules of 160, 160, and 180, the solution ensures each schedule receives its full amount (160, 160, 180 respectively) in order.

---
<a href="https://cursor.com/background-agent?bcId=bc-46bd942b-f2af-45ff-aedd-82f6cdcc1e21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-46bd942b-f2af-45ff-aedd-82f6cdcc1e21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

