### PR TITLE
Allocate receipt amounts to schedules fifo

### DIFF
--- a/fifo_allocation_detailed_view.sql
+++ b/fifo_allocation_detailed_view.sql
@@ -1,0 +1,108 @@
+-- Create a View for Detailed FIFO Allocation Status
+-- This view provides a comprehensive look at allocation status for each schedule
+
+CREATE OR REPLACE VIEW v_fifo_allocation_status AS
+WITH schedule_cumulative AS (
+    SELECT 
+        s.id AS schedule_id,
+        s.journal_voucher_line_id,
+        s.schedule_date,
+        s.schedule_amount,
+        s.received_amount,
+        s.created_at,
+        s.modified_at,
+        SUM(s.schedule_amount) OVER (
+            PARTITION BY s.journal_voucher_line_id 
+            ORDER BY s.schedule_date, s.id
+        ) AS cumulative_schedule_amount,
+        SUM(s.schedule_amount) OVER (
+            PARTITION BY s.journal_voucher_line_id 
+            ORDER BY s.schedule_date, s.id
+            ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+        ) AS prev_cumulative_amount,
+        ROW_NUMBER() OVER (
+            PARTITION BY s.journal_voucher_line_id 
+            ORDER BY s.schedule_date, s.id
+        ) AS schedule_sequence
+    FROM accounting_journal_voucher_line_schedules s
+),
+allocation_details AS (
+    SELECT 
+        jv_line_id,
+        COUNT(*) AS allocation_count,
+        SUM(amount) AS total_allocated_amount,
+        SUM(usd) AS total_allocated_usd,
+        SUM(lbp) AS total_allocated_lbp,
+        MIN(allocated_at) AS first_allocation_date,
+        MAX(allocated_at) AS last_allocation_date,
+        GROUP_CONCAT(DISTINCT currency) AS currencies_used
+    FROM accounting_receipt_allocations
+    WHERE jv_line_id IS NOT NULL
+    GROUP BY jv_line_id
+),
+fifo_calculation AS (
+    SELECT 
+        sc.*,
+        ad.total_allocated_amount,
+        ad.total_allocated_usd,
+        ad.total_allocated_lbp,
+        ad.allocation_count,
+        ad.first_allocation_date,
+        ad.last_allocation_date,
+        ad.currencies_used,
+        CASE 
+            WHEN ad.total_allocated_amount IS NULL THEN 0
+            WHEN ad.total_allocated_amount <= COALESCE(sc.prev_cumulative_amount, 0) THEN 0
+            WHEN ad.total_allocated_amount >= sc.cumulative_schedule_amount THEN sc.schedule_amount
+            ELSE ad.total_allocated_amount - COALESCE(sc.prev_cumulative_amount, 0)
+        END AS calculated_received_amount
+    FROM schedule_cumulative sc
+    LEFT JOIN allocation_details ad ON sc.journal_voucher_line_id = ad.jv_line_id
+)
+SELECT 
+    schedule_id,
+    journal_voucher_line_id,
+    schedule_sequence,
+    schedule_date,
+    schedule_amount,
+    received_amount AS current_received_amount,
+    calculated_received_amount AS fifo_received_amount,
+    schedule_amount - calculated_received_amount AS outstanding_amount,
+    ROUND((calculated_received_amount / schedule_amount) * 100, 2) AS received_percentage,
+    total_allocated_amount,
+    allocation_count,
+    first_allocation_date,
+    last_allocation_date,
+    currencies_used,
+    CASE 
+        WHEN calculated_received_amount = 0 THEN 'Not Received'
+        WHEN calculated_received_amount < schedule_amount THEN 'Partially Received'
+        ELSE 'Fully Received'
+    END AS status,
+    CASE 
+        WHEN calculated_received_amount != received_amount THEN 'Update Required'
+        ELSE 'In Sync'
+    END AS sync_status,
+    created_at,
+    modified_at
+FROM fifo_calculation;
+
+-- Query Examples using the view:
+
+-- 1. Check status for specific JV Line
+-- SELECT * FROM v_fifo_allocation_status WHERE journal_voucher_line_id = 396;
+
+-- 2. Find schedules that need updating
+-- SELECT * FROM v_fifo_allocation_status WHERE sync_status = 'Update Required';
+
+-- 3. Summary by JV Line
+-- SELECT 
+--     journal_voucher_line_id,
+--     COUNT(*) as schedule_count,
+--     SUM(schedule_amount) as total_scheduled,
+--     SUM(fifo_received_amount) as total_received,
+--     SUM(outstanding_amount) as total_outstanding,
+--     ROUND(AVG(received_percentage), 2) as avg_received_percentage
+-- FROM v_fifo_allocation_status
+-- GROUP BY journal_voucher_line_id
+-- HAVING SUM(fifo_received_amount) > 0;

--- a/fifo_allocation_examples.sql
+++ b/fifo_allocation_examples.sql
@@ -1,0 +1,151 @@
+-- FIFO Allocation Examples and Use Cases
+-- This file demonstrates various scenarios for the FIFO allocation system
+
+-- ============================================
+-- SCENARIO 1: Your Example - JV Line 396
+-- ============================================
+-- Total Allocation: 500 USD
+-- Schedules: 160, 160, 180 (Total: 500)
+-- Expected Result: All schedules fully allocated
+
+-- Check current state
+SELECT 
+    'Schedule' as type,
+    id,
+    schedule_date,
+    schedule_amount,
+    received_amount
+FROM accounting_journal_voucher_line_schedules
+WHERE journal_voucher_line_id = 396
+UNION ALL
+SELECT 
+    'Allocation' as type,
+    allocation_id,
+    allocated_at,
+    amount,
+    0
+FROM accounting_receipt_allocations
+WHERE jv_line_id = 396;
+
+-- ============================================
+-- SCENARIO 2: Partial Allocation
+-- ============================================
+-- Example: JV Line has schedules of 200, 300, 400 (Total: 900)
+-- But only 450 has been allocated
+-- Expected: First schedule gets 200, second gets 250, third gets 0
+
+WITH example_scenario AS (
+    SELECT 
+        journal_voucher_line_id,
+        schedule_date,
+        schedule_amount,
+        SUM(schedule_amount) OVER (ORDER BY schedule_date) as running_total,
+        450 as total_allocated -- Example allocation
+    FROM accounting_journal_voucher_line_schedules
+    WHERE journal_voucher_line_id = 397 -- Example JV Line
+)
+SELECT 
+    *,
+    CASE 
+        WHEN total_allocated >= running_total THEN schedule_amount
+        WHEN total_allocated > (running_total - schedule_amount) 
+            THEN total_allocated - (running_total - schedule_amount)
+        ELSE 0
+    END as calculated_allocation
+FROM example_scenario;
+
+-- ============================================
+-- SCENARIO 3: Over-allocation
+-- ============================================
+-- When allocated amount exceeds total scheduled amount
+-- This query finds such cases
+
+SELECT 
+    jvls.journal_voucher_line_id,
+    SUM(jvls.schedule_amount) as total_scheduled,
+    COALESCE(alloc.total_allocated, 0) as total_allocated,
+    COALESCE(alloc.total_allocated, 0) - SUM(jvls.schedule_amount) as over_allocated_amount
+FROM accounting_journal_voucher_line_schedules jvls
+LEFT JOIN (
+    SELECT 
+        jv_line_id,
+        SUM(amount) as total_allocated
+    FROM accounting_receipt_allocations
+    WHERE jv_line_id IS NOT NULL
+    GROUP BY jv_line_id
+) alloc ON jvls.journal_voucher_line_id = alloc.jv_line_id
+GROUP BY jvls.journal_voucher_line_id, alloc.total_allocated
+HAVING COALESCE(alloc.total_allocated, 0) > SUM(jvls.schedule_amount);
+
+-- ============================================
+-- SCENARIO 4: Multiple Currency Allocations
+-- ============================================
+-- When allocations are in different currencies
+
+SELECT 
+    ra.jv_line_id,
+    ra.currency,
+    SUM(ra.amount) as total_in_currency,
+    SUM(ra.usd) as total_in_usd,
+    SUM(ra.lbp) as total_in_lbp,
+    COUNT(*) as allocation_count
+FROM accounting_receipt_allocations ra
+WHERE ra.jv_line_id IS NOT NULL
+GROUP BY ra.jv_line_id, ra.currency
+ORDER BY ra.jv_line_id, ra.currency;
+
+-- ============================================
+-- SCENARIO 5: Allocation Timeline Analysis
+-- ============================================
+-- Shows how allocations were received over time
+
+SELECT 
+    jv_line_id,
+    DATE(allocated_at) as allocation_date,
+    SUM(amount) as daily_allocation,
+    SUM(SUM(amount)) OVER (
+        PARTITION BY jv_line_id 
+        ORDER BY DATE(allocated_at)
+    ) as cumulative_allocation
+FROM accounting_receipt_allocations
+WHERE jv_line_id = 396
+GROUP BY jv_line_id, DATE(allocated_at)
+ORDER BY allocation_date;
+
+-- ============================================
+-- UTILITY QUERY: Verify FIFO Logic
+-- ============================================
+-- This query shows the step-by-step FIFO allocation process
+
+WITH allocation_breakdown AS (
+    SELECT 
+        s.id,
+        s.journal_voucher_line_id,
+        s.schedule_date,
+        s.schedule_amount,
+        @running_schedule := @running_schedule + s.schedule_amount as cumulative_scheduled,
+        @running_schedule - s.schedule_amount as prev_cumulative,
+        (SELECT COALESCE(SUM(amount), 0) 
+         FROM accounting_receipt_allocations 
+         WHERE jv_line_id = s.journal_voucher_line_id) as total_allocated
+    FROM 
+        accounting_journal_voucher_line_schedules s,
+        (SELECT @running_schedule := 0) r
+    WHERE 
+        s.journal_voucher_line_id = 396
+    ORDER BY 
+        s.schedule_date, s.id
+)
+SELECT 
+    *,
+    CASE 
+        WHEN total_allocated <= prev_cumulative THEN 0
+        WHEN total_allocated >= cumulative_scheduled THEN schedule_amount
+        ELSE total_allocated - prev_cumulative
+    END as fifo_allocation,
+    CASE 
+        WHEN total_allocated <= prev_cumulative THEN 'Not Reached'
+        WHEN total_allocated >= cumulative_scheduled THEN 'Fully Allocated'
+        ELSE 'Partially Allocated'
+    END as allocation_status
+FROM allocation_breakdown;

--- a/fifo_allocation_procedure.sql
+++ b/fifo_allocation_procedure.sql
@@ -1,0 +1,113 @@
+-- Stored Procedure for FIFO Allocation Update
+-- This procedure can be called to update received amounts for specific or all journal voucher lines
+
+DELIMITER //
+
+DROP PROCEDURE IF EXISTS update_fifo_allocations//
+
+CREATE PROCEDURE update_fifo_allocations(
+    IN p_jv_line_id INT DEFAULT NULL  -- NULL means update all lines
+)
+BEGIN
+    DECLARE v_error_msg VARCHAR(255);
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        GET DIAGNOSTICS CONDITION 1 v_error_msg = MESSAGE_TEXT;
+        SELECT CONCAT('Error: ', v_error_msg) AS error_message;
+    END;
+    
+    START TRANSACTION;
+    
+    -- Create temporary table with FIFO calculations
+    DROP TEMPORARY TABLE IF EXISTS temp_fifo_calculations;
+    
+    CREATE TEMPORARY TABLE temp_fifo_calculations AS
+    WITH schedule_cumulative AS (
+        SELECT 
+            s.id,
+            s.journal_voucher_line_id,
+            s.schedule_date,
+            s.schedule_amount,
+            SUM(s.schedule_amount) OVER (
+                PARTITION BY s.journal_voucher_line_id 
+                ORDER BY s.schedule_date, s.id
+            ) AS cumulative_schedule_amount,
+            SUM(s.schedule_amount) OVER (
+                PARTITION BY s.journal_voucher_line_id 
+                ORDER BY s.schedule_date, s.id
+                ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+            ) AS prev_cumulative_amount
+        FROM accounting_journal_voucher_line_schedules s
+        WHERE p_jv_line_id IS NULL OR s.journal_voucher_line_id = p_jv_line_id
+    ),
+    allocation_totals AS (
+        SELECT 
+            jv_line_id,
+            SUM(amount) AS total_allocated_amount,
+            SUM(usd) AS total_allocated_usd
+        FROM accounting_receipt_allocations
+        WHERE jv_line_id IS NOT NULL
+            AND (p_jv_line_id IS NULL OR jv_line_id = p_jv_line_id)
+        GROUP BY jv_line_id
+    )
+    SELECT 
+        sc.id AS schedule_id,
+        sc.journal_voucher_line_id,
+        sc.schedule_date,
+        sc.schedule_amount,
+        CASE 
+            WHEN at.total_allocated_amount IS NULL THEN 0
+            WHEN at.total_allocated_amount <= COALESCE(sc.prev_cumulative_amount, 0) THEN 0
+            WHEN at.total_allocated_amount >= sc.cumulative_schedule_amount THEN sc.schedule_amount
+            ELSE at.total_allocated_amount - COALESCE(sc.prev_cumulative_amount, 0)
+        END AS new_received_amount,
+        at.total_allocated_amount,
+        at.total_allocated_usd
+    FROM schedule_cumulative sc
+    LEFT JOIN allocation_totals at ON sc.journal_voucher_line_id = at.jv_line_id;
+    
+    -- Update the schedules table
+    UPDATE accounting_journal_voucher_line_schedules s
+    INNER JOIN temp_fifo_calculations t ON s.id = t.schedule_id
+    SET 
+        s.received_amount = t.new_received_amount,
+        s.modified_at = CURRENT_TIMESTAMP,
+        s.modified_by = USER()
+    WHERE s.received_amount != t.new_received_amount  -- Only update if value changed
+        OR s.received_amount IS NULL;
+    
+    -- Get summary of updates
+    SELECT 
+        journal_voucher_line_id,
+        COUNT(*) AS schedules_count,
+        SUM(schedule_amount) AS total_scheduled,
+        SUM(new_received_amount) AS total_received,
+        MAX(total_allocated_amount) AS total_allocated,
+        CASE 
+            WHEN SUM(new_received_amount) = 0 THEN 'No Allocation'
+            WHEN SUM(new_received_amount) < SUM(schedule_amount) THEN 'Partial Allocation'
+            ELSE 'Full Allocation'
+        END AS allocation_status
+    FROM temp_fifo_calculations
+    GROUP BY journal_voucher_line_id
+    ORDER BY journal_voucher_line_id;
+    
+    -- Clean up
+    DROP TEMPORARY TABLE temp_fifo_calculations;
+    
+    COMMIT;
+    
+    SELECT 'FIFO allocation update completed successfully' AS status;
+    
+END//
+
+DELIMITER ;
+
+-- Usage Examples:
+
+-- Update all journal voucher lines
+-- CALL update_fifo_allocations(NULL);
+
+-- Update specific journal voucher line (e.g., 396)
+-- CALL update_fifo_allocations(396);

--- a/fifo_allocation_query.sql
+++ b/fifo_allocation_query.sql
@@ -1,0 +1,75 @@
+-- FIFO Allocation Matching Query
+-- This query matches allocations to schedules using FIFO logic
+-- For each journal voucher line, it distributes allocated amounts across schedules in chronological order
+
+-- CTE to get cumulative amounts for schedules (ordered by schedule_date for FIFO)
+WITH schedule_cumulative AS (
+    SELECT 
+        s.id,
+        s.journal_voucher_line_id,
+        s.schedule_date,
+        s.schedule_amount,
+        s.received_amount,
+        SUM(s.schedule_amount) OVER (
+            PARTITION BY s.journal_voucher_line_id 
+            ORDER BY s.schedule_date, s.id
+        ) AS cumulative_schedule_amount,
+        SUM(s.schedule_amount) OVER (
+            PARTITION BY s.journal_voucher_line_id 
+            ORDER BY s.schedule_date, s.id
+            ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+        ) AS prev_cumulative_amount
+    FROM accounting_journal_voucher_line_schedules s
+),
+-- CTE to get total allocations per journal voucher line
+allocation_totals AS (
+    SELECT 
+        jv_line_id,
+        SUM(amount) AS total_allocated_amount,
+        SUM(usd) AS total_allocated_usd,
+        SUM(lbp) AS total_allocated_lbp
+    FROM accounting_receipt_allocations
+    WHERE jv_line_id IS NOT NULL
+    GROUP BY jv_line_id
+),
+-- Calculate the FIFO-based received amount for each schedule
+fifo_calculation AS (
+    SELECT 
+        sc.id,
+        sc.journal_voucher_line_id,
+        sc.schedule_date,
+        sc.schedule_amount,
+        sc.received_amount AS current_received_amount,
+        COALESCE(at.total_allocated_amount, 0) AS total_allocated,
+        COALESCE(sc.prev_cumulative_amount, 0) AS prev_cumulative,
+        sc.cumulative_schedule_amount,
+        -- Calculate FIFO received amount
+        CASE 
+            WHEN at.total_allocated_amount IS NULL THEN 0
+            WHEN at.total_allocated_amount <= COALESCE(sc.prev_cumulative_amount, 0) THEN 0
+            WHEN at.total_allocated_amount >= sc.cumulative_schedule_amount THEN sc.schedule_amount
+            ELSE at.total_allocated_amount - COALESCE(sc.prev_cumulative_amount, 0)
+        END AS calculated_received_amount
+    FROM schedule_cumulative sc
+    LEFT JOIN allocation_totals at ON sc.journal_voucher_line_id = at.jv_line_id
+)
+-- Final result
+SELECT 
+    id AS schedule_id,
+    journal_voucher_line_id,
+    schedule_date,
+    schedule_amount,
+    current_received_amount,
+    calculated_received_amount AS fifo_received_amount,
+    total_allocated,
+    CASE 
+        WHEN calculated_received_amount = schedule_amount THEN 'Fully Received'
+        WHEN calculated_received_amount > 0 THEN 'Partially Received'
+        ELSE 'Not Received'
+    END AS status
+FROM fifo_calculation
+ORDER BY journal_voucher_line_id, schedule_date, id;
+
+-- Example for JV LINE ID 396
+-- Uncomment the WHERE clause below to filter for specific journal voucher line
+-- WHERE journal_voucher_line_id = 396

--- a/test_fifo_example.sql
+++ b/test_fifo_example.sql
@@ -1,0 +1,73 @@
+-- Test Example for JV LINE ID 396
+-- This demonstrates how the FIFO allocation works with your example:
+-- 3 schedules (160, 160, 180) with total allocation of 500
+
+-- Step 1: View current schedules for JV LINE ID 396
+SELECT 
+    id,
+    journal_voucher_line_id,
+    schedule_date,
+    schedule_amount,
+    received_amount
+FROM accounting_journal_voucher_line_schedules
+WHERE journal_voucher_line_id = 396
+ORDER BY schedule_date, id;
+
+-- Step 2: View allocations for JV LINE ID 396
+SELECT 
+    allocation_id,
+    jv_line_id,
+    amount,
+    usd,
+    allocated_at
+FROM accounting_receipt_allocations
+WHERE jv_line_id = 396
+ORDER BY allocated_at;
+
+-- Step 3: Calculate FIFO allocation breakdown
+WITH schedule_ordered AS (
+    SELECT 
+        id,
+        journal_voucher_line_id,
+        schedule_date,
+        schedule_amount,
+        ROW_NUMBER() OVER (ORDER BY schedule_date, id) AS schedule_order,
+        SUM(schedule_amount) OVER (ORDER BY schedule_date, id) AS running_total,
+        SUM(schedule_amount) OVER (ORDER BY schedule_date, id ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS prev_running_total
+    FROM accounting_journal_voucher_line_schedules
+    WHERE journal_voucher_line_id = 396
+),
+total_allocation AS (
+    SELECT 
+        SUM(amount) AS total_allocated
+    FROM accounting_receipt_allocations
+    WHERE jv_line_id = 396
+)
+SELECT 
+    so.id AS schedule_id,
+    so.schedule_date,
+    so.schedule_amount,
+    so.schedule_order,
+    COALESCE(so.prev_running_total, 0) AS cumulative_before,
+    so.running_total AS cumulative_after,
+    ta.total_allocated,
+    CASE 
+        WHEN ta.total_allocated <= COALESCE(so.prev_running_total, 0) THEN 0
+        WHEN ta.total_allocated >= so.running_total THEN so.schedule_amount
+        ELSE ta.total_allocated - COALESCE(so.prev_running_total, 0)
+    END AS allocated_to_this_schedule,
+    CASE 
+        WHEN ta.total_allocated <= COALESCE(so.prev_running_total, 0) THEN 'Not Reached'
+        WHEN ta.total_allocated >= so.running_total THEN 'Fully Allocated'
+        ELSE 'Partially Allocated'
+    END AS allocation_status
+FROM schedule_ordered so
+CROSS JOIN total_allocation ta
+ORDER BY so.schedule_order;
+
+-- Example Output Explanation:
+-- If total allocation is 500 and schedules are:
+-- Schedule 1: 160 (cumulative: 0-160)    -> Gets 160 (fully allocated)
+-- Schedule 2: 160 (cumulative: 160-320)  -> Gets 160 (fully allocated)
+-- Schedule 3: 180 (cumulative: 320-500)  -> Gets 180 (fully allocated)
+-- Total: 500 allocated across all schedules

--- a/update_received_amounts.sql
+++ b/update_received_amounts.sql
@@ -1,0 +1,67 @@
+-- Update Statement to Apply FIFO Allocation to Schedule Table
+-- This query updates the received_amount field in the schedules table based on FIFO allocation
+
+-- First, let's create a temporary table with the FIFO calculations
+CREATE TEMPORARY TABLE temp_fifo_updates AS
+WITH schedule_cumulative AS (
+    SELECT 
+        s.id,
+        s.journal_voucher_line_id,
+        s.schedule_date,
+        s.schedule_amount,
+        SUM(s.schedule_amount) OVER (
+            PARTITION BY s.journal_voucher_line_id 
+            ORDER BY s.schedule_date, s.id
+        ) AS cumulative_schedule_amount,
+        SUM(s.schedule_amount) OVER (
+            PARTITION BY s.journal_voucher_line_id 
+            ORDER BY s.schedule_date, s.id
+            ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+        ) AS prev_cumulative_amount
+    FROM accounting_journal_voucher_line_schedules s
+),
+allocation_totals AS (
+    SELECT 
+        jv_line_id,
+        SUM(amount) AS total_allocated_amount
+    FROM accounting_receipt_allocations
+    WHERE jv_line_id IS NOT NULL
+    GROUP BY jv_line_id
+)
+SELECT 
+    sc.id,
+    CASE 
+        WHEN at.total_allocated_amount IS NULL THEN 0
+        WHEN at.total_allocated_amount <= COALESCE(sc.prev_cumulative_amount, 0) THEN 0
+        WHEN at.total_allocated_amount >= sc.cumulative_schedule_amount THEN sc.schedule_amount
+        ELSE at.total_allocated_amount - COALESCE(sc.prev_cumulative_amount, 0)
+    END AS new_received_amount
+FROM schedule_cumulative sc
+LEFT JOIN allocation_totals at ON sc.journal_voucher_line_id = at.jv_line_id;
+
+-- Update the schedules table
+UPDATE accounting_journal_voucher_line_schedules s
+INNER JOIN temp_fifo_updates t ON s.id = t.id
+SET 
+    s.received_amount = t.new_received_amount,
+    s.modified_at = CURRENT_TIMESTAMP,
+    s.modified_by = USER();
+
+-- Clean up
+DROP TEMPORARY TABLE temp_fifo_updates;
+
+-- Verify the update for JV LINE ID 396
+SELECT 
+    id,
+    journal_voucher_line_id,
+    schedule_date,
+    schedule_amount,
+    received_amount,
+    CASE 
+        WHEN received_amount = schedule_amount THEN 'Fully Received'
+        WHEN received_amount > 0 THEN 'Partially Received'
+        ELSE 'Not Received'
+    END AS status
+FROM accounting_journal_voucher_line_schedules
+WHERE journal_voucher_line_id = 396
+ORDER BY schedule_date, id;


### PR DESCRIPTION
Implement FIFO allocation logic to update `received_amount` in `accounting_journal_voucher_line_schedules` based on `accounting_receipt_allocations`.

This change addresses the need to distribute allocated amounts across schedules for a given journal voucher line on a First-In, First-Out basis, ensuring that older schedules are fully satisfied before newer ones.

---
<a href="https://cursor.com/background-agent?bcId=bc-983bd477-6df8-4b25-9f05-aa6ccd761264">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-983bd477-6df8-4b25-9f05-aa6ccd761264">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

